### PR TITLE
Potential fix for code scanning alert no. 6: Uncontrolled data used in path expression

### DIFF
--- a/misc/snmp/snmp-server.py
+++ b/misc/snmp/snmp-server.py
@@ -678,8 +678,14 @@ def get_next(oids, oid):
 def parse_config(filename):
     """Read and parse a config"""
     oids = {}
+    safe_root = '/etc/snmp'  # Define a safe root directory for configuration files
     try:
-        with open(filename, 'r', encoding='utf-8') as conf_file:
+        # Normalize the path and ensure it is within the safe root directory
+        normalized_path = os.path.normpath(filename)
+        if not normalized_path.startswith(safe_root):
+            raise ConfigError("Access to the specified file is not allowed.")
+
+        with open(normalized_path, 'r', encoding='utf-8') as conf_file:
             try:
                 oids = json.load(conf_file)
                 if not isinstance(oids, dict):


### PR DESCRIPTION
Potential fix for [https://github.com/simonccc/btsmarthub-utils/security/code-scanning/6](https://github.com/simonccc/btsmarthub-utils/security/code-scanning/6)

To fix the issue, we need to validate the `filename` before using it in the `open()` function. The best approach is to ensure that the file path is contained within a safe root directory. This can be achieved by:
1. Defining a safe root directory for configuration files.
2. Normalizing the user-provided path using `os.path.normpath` to remove any `..` segments.
3. Verifying that the normalized path starts with the safe root directory.

This fix ensures that even if a malicious user provides a path with directory traversal characters, the code will reject it if it attempts to escape the safe root directory.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
