### PR TITLE
Potential fix for code scanning alert no. 3: Full server-side request forgery

### DIFF
--- a/docker/smarthub.py
+++ b/docker/smarthub.py
@@ -33,6 +33,10 @@ except:
 try:
   DOCKER_URL=os.environ['URL']
   DOCKER_PASS=os.environ['PASS']
+  ALLOWED_URLS = ["http://example.com", "http://another-example.com"]  # Whitelist of allowed URLs
+  if DOCKER_URL not in ALLOWED_URLS:
+      print(f"Invalid URL provided: {DOCKER_URL}", file=sys.stderr)
+      sys.exit(1)
 except:
   print('NO URL OR PASS DEFINED. EXITING',file=sys.stderr)
   sys.exit(1)
@@ -207,7 +211,8 @@ while True:
     if ( str(ts) == str(event_timestamp)):
         ts = (int(ts) + 1 )
 
-  vars = (requests.get(DOCKER_URL + '/cgi/cgi_basicMyDevice.js').content.decode()).split('var')
+  validated_url = DOCKER_URL.rstrip('/') + '/cgi/cgi_basicMyDevice.js'
+  vars = (requests.get(validated_url).content.decode()).split('var')
   rate = vars[2].split('\n')
 
   for rate in rate:


### PR DESCRIPTION
Potential fix for [https://github.com/simonccc/btsmarthub-utils/security/code-scanning/3](https://github.com/simonccc/btsmarthub-utils/security/code-scanning/3)

To fix the issue, we need to ensure that the `DOCKER_URL` value is validated before it is used to construct the URL for the HTTP request. A whitelist-based approach is recommended, where only pre-approved URLs or domains are allowed. Alternatively, we can parse and verify the URL to ensure it does not point to private or unauthorized IP addresses.

Steps to fix:
1. Introduce a whitelist of allowed base URLs or domains.
2. Validate the `DOCKER_URL` against this whitelist before using it in the `requests.get` call.
3. If the `DOCKER_URL` is invalid or not in the whitelist, log an error and exit or handle the situation gracefully.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
