### PR TITLE
Potential fix for code scanning alert no. 2: Full server-side request forgery

### DIFF
--- a/docker/smarthub.py
+++ b/docker/smarthub.py
@@ -149,6 +149,9 @@ while True:
   parsed_events = {}
 
   # request status page with latest time stamp
+  if not validate_url(DOCKER_URL):
+      print(f"Invalid or unsafe URL provided: {DOCKER_URL}", file=sys.stderr)
+      sys.exit(1)
   r = requests.get(DOCKER_URL + '/cgi/cgi_helpdesk.js?t=' + str(ts), cookies=cookies, allow_redirects=False)
 
   # if a 302 login


### PR DESCRIPTION
Potential fix for [https://github.com/simonccc/btsmarthub-utils/security/code-scanning/2](https://github.com/simonccc/btsmarthub-utils/security/code-scanning/2)

To fix the issue, we need to ensure that the `DOCKER_URL` value is validated immediately before it is used in the HTTP request. This can be achieved by invoking the `validate_url` function right before the `requests.get` call on line 152. If the URL is invalid, the program should log an error and terminate or handle the error gracefully. This ensures that even if the `DOCKER_URL` value is modified after the initial validation, it is still checked for safety before being used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
