### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,6 +2,9 @@ name: Pylint
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/simonccc/btsmarthub-utils/security/code-scanning/10](https://github.com/simonccc/btsmarthub-utils/security/code-scanning/10)

To fix the issue, add a `permissions` block at the root of the workflow file. Since the workflow only needs to read the repository contents to run `pylint`, the `contents: read` permission is sufficient. This change ensures that the workflow has the minimum required permissions and adheres to security best practices.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
